### PR TITLE
Fixed Internal Dictionaries not being updated on DeSerialization

### DIFF
--- a/src/Aquarius.ONE.ClientSDK/Aquarius.ONE.ClientSDK.csproj
+++ b/src/Aquarius.ONE.ClientSDK/Aquarius.ONE.ClientSDK.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <!--For Release packages update the VersionPrefix and remove any VersionSuffix-->
-	  <VersionPrefix>11.8.0</VersionPrefix>
+	  <VersionPrefix>11.8.1</VersionPrefix>
 	  <!--For Feature packages update the VersionSuffix with the Jira ticket number-->
 	  <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Aquarius.ONE.ClientSDK/ClientSDK.cs
+++ b/src/Aquarius.ONE.ClientSDK/ClientSDK.cs
@@ -1,4 +1,4 @@
-﻿using ONE.Common.Activity;
+using ONE.Common.Activity;
 using ONE.Common.Configuration;
 using ONE.Common.Historian;
 using ONE.Common.Library;

--- a/src/Aquarius.ONE.ClientSDK/Operations/OperationCache.cs
+++ b/src/Aquarius.ONE.ClientSDK/Operations/OperationCache.cs
@@ -285,8 +285,8 @@ namespace ONE.Operations
                     DashboardsTask
                     );
 
-                ColumnTwins = ColumnTwinsTask.Result;
-                LocationTwins = LocationTwinsTask.Result;
+                ColumnTwins = ColumnTwinsTask.Result ?? new List<DigitalTwin>();
+                LocationTwins = LocationTwinsTask.Result ?? new List<DigitalTwin>();
                 SpreadsheetDefinition = SpreadsheetDefinitionTask.Result;
                 FifteenMinuteWorksheetDefinition = FifteenMinuteWorksheetDefinitionTask.Result;
                 HourlyWorksheetDefinition = HourlyWorksheetDefinitionTask.Result;

--- a/src/Aquarius.ONE.ClientSDK/Operations/OperationCache.cs
+++ b/src/Aquarius.ONE.ClientSDK/Operations/OperationCache.cs
@@ -41,8 +41,6 @@ namespace ONE.Operations
                 var operationCache = JsonConvert.DeserializeObject<OperationCache>(serializedObject, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
                 DigitalTwin = operationCache.DigitalTwin;
                 DigitalTwinItem = operationCache.DigitalTwinItem;
-                ItemDictionarybyGuid = operationCache.ItemDictionarybyGuid;
-                ItemDictionarybyLong = operationCache.ItemDictionarybyLong;
 
                 SpreadsheetDefinition = operationCache.SpreadsheetDefinition;
                 FifteenMinuteWorksheetDefinition = operationCache.FifteenMinuteWorksheetDefinition;
@@ -69,6 +67,9 @@ namespace ONE.Operations
                 Graphs = operationCache.Graphs;
                 Dashboards = operationCache.Dashboards;
 
+                var allOperationDecendentTwins = LocationTwins.Union(ColumnTwins).ToList();
+
+                AddChildren(DigitalTwinItem, allOperationDecendentTwins);
                 CacheColumns();
             }
             catch
@@ -308,9 +309,9 @@ namespace ONE.Operations
                 return false;
             }
             //Merge the Twins
-            var allChildTwins = LocationTwins.Union(ColumnTwins).ToList();
+            var allOperationDecendentTwins = LocationTwins.Union(ColumnTwins).ToList();
             
-            AddChildren(DigitalTwinItem, allChildTwins);
+            AddChildren(DigitalTwinItem, allOperationDecendentTwins);
             IsCached = true;
             CacheColumns();
             return true;
@@ -418,7 +419,7 @@ namespace ONE.Operations
                 return null;
             if (ColumnsById.ContainsKey(id))
                 return ColumnsById[id];
-            Column column = ONE.Operations.Spreadsheet.Helper.GetColumnByNumber(FifteenMinuteWorksheetDefinition, id);
+            Column column = Spreadsheet.Helper.GetColumnByNumber(FifteenMinuteWorksheetDefinition, id);
             if (column != null)
                 return column;
             column = ONE.Operations.Spreadsheet.Helper.GetColumnByNumber(HourlyWorksheetDefinition, id);
@@ -595,7 +596,7 @@ namespace ONE.Operations
             return GetWorksheetType(digitalTwin);
         }
 
-        private void AddChildren(DigitalTwinItem digitalTwinTreeItem, List<DigitalTwin> digitalTwins)
+        public void AddChildren(DigitalTwinItem digitalTwinTreeItem, List<DigitalTwin> digitalTwins)
         {
             var childDigitalTwins = digitalTwins.Where(p => p.ParentId == digitalTwinTreeItem.DigitalTwin.Id);
             foreach (DigitalTwin digitalTwin in childDigitalTwins)

--- a/src/Aquarius.ONE.ClientSDK/Operations/OperationCache.cs
+++ b/src/Aquarius.ONE.ClientSDK/Operations/OperationCache.cs
@@ -58,8 +58,8 @@ namespace ONE.Operations
                 Delimiter = operationCache.Delimiter;
                 IsCached = operationCache.IsCached;
 
-                LocationTwins = operationCache.LocationTwins;
-                ColumnTwins = operationCache.ColumnTwins;
+                LocationTwins = operationCache.LocationTwins ?? new List<DigitalTwin>();
+                ColumnTwins = operationCache.ColumnTwins ?? new List<DigitalTwin>();
                 Users = operationCache.Users;
 
                 SpreadsheetComputations = operationCache.SpreadsheetComputations;
@@ -327,7 +327,7 @@ namespace ONE.Operations
                     if (sourceColumn.DataSourceBinding != null && !string.IsNullOrEmpty(sourceColumn.DataSourceBinding.BindingId))
                     {
                         SpreadsheetComputation sourceSpreadsheetComputation = await _clientSDK.Spreadsheet.ComputationGetOneAsync(DigitalTwin.TwinReferenceId, sourceWorksheetDefinition.EnumWorksheet, sourceColumn.DataSourceBinding.BindingId);
-                        if (sourceSpreadsheetComputation != null)
+                        if (sourceSpreadsheetComputation != null && !SpreadsheetComputations.ContainsKey(sourceColumn.DataSourceBinding.BindingId))
                         {
                             SpreadsheetComputations.Add(sourceColumn.DataSourceBinding.BindingId, sourceSpreadsheetComputation);
                         }

--- a/src/Aquarius.ONE.ClientSDK/Operations/OperationsCache.cs
+++ b/src/Aquarius.ONE.ClientSDK/Operations/OperationsCache.cs
@@ -25,6 +25,8 @@ namespace ONE.Operations
                 foreach (var operationCache in Operations)
                 {
                     operationCache.SetClientSDK(clientSDK);
+                    var allOperationDecendentTwins = operationCache.LocationTwins.Union(operationCache.ColumnTwins).ToList();
+                    operationCache.AddChildren(operationCache.DigitalTwinItem, allOperationDecendentTwins);
                     operationCache.CacheColumns();
                 }
             }
@@ -37,6 +39,8 @@ namespace ONE.Operations
                 Operations = operationsCache.Operations;
                 foreach (var operationCache in Operations)
                 {
+                    var allOperationDecendentTwins = operationCache.LocationTwins.Union(operationCache.ColumnTwins).ToList();
+                    operationCache.AddChildren(operationCache.DigitalTwinItem, allOperationDecendentTwins);
                     operationCache.CacheColumns();
                 }
             }
@@ -63,7 +67,7 @@ namespace ONE.Operations
         {
             Operations = new List<OperationCache>();
         }
-        public async Task<List<OperationCache>> LoadOperationsAsync()
+        public async Task<List<OperationCache>> LoadOperationsAsync(bool loadAllOperationCaches = false)
         {
             if (_clientSDK.Authentication.User == null)
             {
@@ -71,10 +75,19 @@ namespace ONE.Operations
                 _clientSDK.Authentication.User = await _clientSDK.UserHelper.GetUserFromUserInfoAsync(result);
             }
             var operationTwins = await _clientSDK.DigitalTwin.GetDescendantsByTypeAsync(_clientSDK.Authentication.User.TenantId, Constants.SpaceCategory.OperationType.RefId);
+            var cacheTasks = new List<Task>();
             foreach (var operationTwin in operationTwins)
             {
-                Operations.Add(new OperationCache(_clientSDK, operationTwin));
+                var operationCache = new OperationCache(_clientSDK, operationTwin);
+                Operations.Add(operationCache);
+                if (loadAllOperationCaches)
+                {
+                    var cacheTask = operationCache.LoadAsync();
+                    cacheTasks.Add(cacheTask);
+                }
             }
+            if (loadAllOperationCaches && cacheTasks.Count > 0)
+                await Task.WhenAll(cacheTasks);
             Operations = Operations.OrderBy(p => p.Name).ToList();
             return Operations;
         }

--- a/src/Aquarius.ONE.ClientSDK/Operations/OperationsCache.cs
+++ b/src/Aquarius.ONE.ClientSDK/Operations/OperationsCache.cs
@@ -75,19 +75,16 @@ namespace ONE.Operations
                 _clientSDK.Authentication.User = await _clientSDK.UserHelper.GetUserFromUserInfoAsync(result);
             }
             var operationTwins = await _clientSDK.DigitalTwin.GetDescendantsByTypeAsync(_clientSDK.Authentication.User.TenantId, Constants.SpaceCategory.OperationType.RefId);
-            var cacheTasks = new List<Task>();
+
             foreach (var operationTwin in operationTwins)
             {
                 var operationCache = new OperationCache(_clientSDK, operationTwin);
                 Operations.Add(operationCache);
+                
                 if (loadAllOperationCaches)
-                {
-                    var cacheTask = operationCache.LoadAsync();
-                    cacheTasks.Add(cacheTask);
-                }
+                    await operationCache.LoadAsync();
             }
-            if (loadAllOperationCaches && cacheTasks.Count > 0)
-                await Task.WhenAll(cacheTasks);
+            
             Operations = Operations.OrderBy(p => p.Name).ToList();
             return Operations;
         }

--- a/src/Aquarius.ONE.Test.ConsoleApp/Program.cs
+++ b/src/Aquarius.ONE.Test.ConsoleApp/Program.cs
@@ -12,6 +12,7 @@ namespace Aquarius.ONE.Test.ConsoleApp
         static async Task<int> Main(string[] args)
         {
             ClientSDK clientSDK = new ClientSDK();
+
             clientSDK.Logger.Event += new EventHandler<ClientApiLoggerEventArgs>(SdkEvent);
             // If no arguments prompt for login
             if (args.Length == 0)
@@ -40,6 +41,7 @@ namespace Aquarius.ONE.Test.ConsoleApp
 
                 clientSDK = CommandHelper.LoadConfig();
                 clientSDK.LogRestfulCalls = true;
+
                 if (!clientSDK.Authentication.IsAuthenticated)
                 {
                     Console.WriteLine("User not Authenticated");

--- a/src/Aquarius.ONE.Test.ConsoleApp/Properties/launchSettings.json
+++ b/src/Aquarius.ONE.Test.ConsoleApp/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Aquarius.ONE.Test.ConsoleApp": {
       "commandName": "Project",
-      "commandLineArgs": "data -a get -g hello"
+      "commandLineArgs": "operations -c clear"
     }
   }
 }

--- a/src/Aquarius.ONE.Test.ConsoleApp/Properties/launchSettings.json
+++ b/src/Aquarius.ONE.Test.ConsoleApp/Properties/launchSettings.json
@@ -3,6 +3,7 @@
     "Aquarius.ONE.Test.ConsoleApp": {
       "commandName": "Project",
       "commandLineArgs": "operations -c clear"
+      //operations -c clear
     }
   }
 }


### PR DESCRIPTION
Added Optional Parameter to Operations.Load to cascade the load of all of the operation caches.
Also -> Reason for the bug -> The Telemetry paths were determined from some internal dictionaries that were not being re-populated when the cache was serialized and then deserialized.