### PR TITLE
Added options to instantiate ClientSDK with Environment

### DIFF
--- a/src/Aquarius.ONE.ClientSDK/ClientSDK.cs
+++ b/src/Aquarius.ONE.ClientSDK/ClientSDK.cs
@@ -53,6 +53,20 @@ namespace ONE
             Authentication.HttpJsonClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue($"Bearer", token);
             Authentication.HttpProtocolBufferClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue($"Bearer", token);
         }
+        public ClientSDK(string environment, bool throwApiErrors = false)
+        {
+            ThrowAPIErrors = throwApiErrors;
+            Logger = new EventLogger();
+            InstantiateAPIs();
+            Environment = PlatformEnvironmentHelper.GetPlatformEnvironment(environment);
+        }
+        public ClientSDK(EnumPlatformEnvironment platformEnvironment, bool throwApiErrors = false)
+        {
+            ThrowAPIErrors = throwApiErrors;
+            Logger = new EventLogger();
+            InstantiateAPIs();
+            Environment = PlatformEnvironmentHelper.GetPlatformEnvironment(platformEnvironment);
+        }
         private PlatformEnvironment _environment { get; set; }
         public PlatformEnvironment Environment
         {

--- a/src/Aquarius.ONE.ClientSDK/Enterprise/Authentication/AuthenticationApi.cs
+++ b/src/Aquarius.ONE.ClientSDK/Enterprise/Authentication/AuthenticationApi.cs
@@ -325,7 +325,7 @@ namespace ONE.Enterprise.Authentication
         {
             get
             {
-                return Token != null && !string.IsNullOrEmpty(Token.access_token) && Token.expires >= DateTime.Now;
+                return Token != null && !string.IsNullOrEmpty(Token.access_token) && Token.expires >= DateTime.Now.AddMinutes(1);
             }
         }
     }

--- a/src/Aquarius.ONE.Test.ConsoleApp/Properties/launchSettings.json
+++ b/src/Aquarius.ONE.Test.ConsoleApp/Properties/launchSettings.json
@@ -2,9 +2,7 @@
   "profiles": {
     "Aquarius.ONE.Test.ConsoleApp": {
       "commandName": "Project",
-      "commandLineArgs": "operations -p c:\\rio"
-      //operations -p c:\\rio
-      //operations -c clear
+      "commandLineArgs": ""
     }
   }
 }


### PR DESCRIPTION
Added additional constructors to instantiate SDK with environment as text or enum.
Also added a minute to the comparison of the token expiration to ensure that the token has a chance of working.