### PR TITLE
Feature/aqi 3451

### DIFF
--- a/src/Aquarius.ONE.ClientSDK/Aquarius.ONE.ClientSDK.csproj
+++ b/src/Aquarius.ONE.ClientSDK/Aquarius.ONE.ClientSDK.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <!--For Release packages update the VersionPrefix and remove any VersionSuffix-->
-	  <VersionPrefix>13.6.0</VersionPrefix>
+	  <VersionPrefix>13.7.0</VersionPrefix>
 	  <!--For Feature packages update the VersionSuffix with the Jira ticket number-->
-	  <VersionSuffix></VersionSuffix>
+	  <VersionSuffix>pre-1</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Aquatic Informatics</Authors>
     <Company>Aquatic Informatics</Company>

--- a/src/Aquarius.ONE.ClientSDK/Aquarius.ONE.ClientSDK.csproj
+++ b/src/Aquarius.ONE.ClientSDK/Aquarius.ONE.ClientSDK.csproj
@@ -5,7 +5,7 @@
 	  <!--For Release packages update the VersionPrefix and remove any VersionSuffix-->
 	  <VersionPrefix>13.7.0</VersionPrefix>
 	  <!--For Feature packages update the VersionSuffix with the Jira ticket number-->
-	  <VersionSuffix>pre-1</VersionSuffix>
+	  <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Aquatic Informatics</Authors>
     <Company>Aquatic Informatics</Company>

--- a/src/Aquarius.ONE.ClientSDK/Common/Configuration/ConfigurationApi.cs
+++ b/src/Aquarius.ONE.ClientSDK/Common/Configuration/ConfigurationApi.cs
@@ -433,7 +433,7 @@ namespace ONE.Common.Configuration
 
             List<proto.ConfigurationNote> configurationNotes = new List<proto.ConfigurationNote>();
  
-            string endpointUrl = $"common/configuration/v2/notes/{configurationId}?startDate={startDate}&endDate={endDate}";
+            string endpointUrl = $"common/configuration/v2/notes/{configurationId}?startDate={startDate:O}&endDate={endDate:O}";
 
             if (!string.IsNullOrWhiteSpace(tagString))
             {

--- a/src/Aquarius.ONE.ClientSDK/Common/Configuration/ConfigurationApi.cs
+++ b/src/Aquarius.ONE.ClientSDK/Common/Configuration/ConfigurationApi.cs
@@ -432,7 +432,13 @@ namespace ONE.Common.Configuration
             var requestId = Guid.NewGuid();
 
             List<proto.ConfigurationNote> configurationNotes = new List<proto.ConfigurationNote>();
- 
+
+            if (startDate.Kind == DateTimeKind.Local)
+                startDate = startDate.ToUniversalTime();
+
+            if (endDate.Kind == DateTimeKind.Local)
+                endDate = endDate.ToUniversalTime();
+            
             string endpointUrl = $"common/configuration/v2/notes/{configurationId}?startDate={startDate:O}&endDate={endDate:O}";
 
             if (!string.IsNullOrWhiteSpace(tagString))


### PR DESCRIPTION
Convert Local dateTimes to UTC before adding them to the url, this allows the .net modelbinder to correctly bind the string to a dateTime object.