### PR TITLE
AQI-10368: ONE.ClientSDK: SampleApi.CreateOneActivityAsync is not returning results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Version 19.0.0 - 2025-01-20
+- Updated SampleApi.CreateOneActivityAsync to return key-value data instead of just a success flag
+
 ## Version 18.4.1 - 2025-12-17
 - Disable local file logging on failure to write log file
 

--- a/src/ONE.ClientSDK/ONE.ClientSDK.csproj
+++ b/src/ONE.ClientSDK/ONE.ClientSDK.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<TargetFramework>netstandard2.0</TargetFramework>
 	  <!--For Release packages update the VersionPrefix and remove any VersionSuffix-->
-	  <VersionPrefix>18.4.1</VersionPrefix>
+	  <VersionPrefix>19.0.0</VersionPrefix>
 	  <!--For Pre-release packages update the VersionSuffix -->
 	  <VersionSuffix></VersionSuffix>
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/ONE.ClientSDK/Operations/Sample/SampleApi.cs
+++ b/src/ONE.ClientSDK/Operations/Sample/SampleApi.cs
@@ -96,27 +96,27 @@ namespace ONE.ClientSDK.Operations.Sample
 		}
 
         /// <summary>
-        /// Creates one sample activity.
+        /// Creates one sample activity and returns details about the created activity.
         /// </summary>
         /// <param name="operationId">ID of the operation to create sample activities for.</param>
         /// <param name="endDate">The last day to create sample activities for.</param>
         /// <param name="propertyBag">Property bag for a sample activity.</param>
         /// <param name="cancellation"></param>
-        /// <returns>Boolean value indicating whether the sample activity was successfully created.</returns>
-        public async Task<bool> CreateOneActivityAsync(string operationId, DateTime endDate, ActivityCollectionPropertyBag propertyBag, CancellationToken cancellation = default)
+        /// <returns>KeyValues collection that includes the id of the sample activity that was created.</returns>
+        public async Task<List<KeyValue>> CreateOneActivityAsync(string operationId, DateTime endDate, ActivityCollectionPropertyBag propertyBag, CancellationToken cancellation = default)
         {
             var endpoint = $"/operations/sample/v1/{operationId}/{endDate:O}/activity";
             var apiResponse = await ExecuteRequest("CreateOneActivityAsync", HttpMethod.Post, endpoint, cancellation, propertyBag, true).ConfigureAwait(_continueOnCapturedContext);
-			return apiResponse != null && apiResponse.StatusCode.IsSuccessStatusCode();
+            return apiResponse?.Content?.KeyValues?.Items.ToList();
         }
 
-		/// <summary>
-		/// Creates an analyte
-		/// </summary>
-		/// <param name="analyte">Analyte to be created</param>
-		/// <param name="cancellation"></param>
-		/// <returns>Boolean value indicating whether the analyte was successfully created</returns>
-		public async Task<bool> CreateAnalyteAsync(Analyte analyte, CancellationToken cancellation = default)
+        /// <summary>
+        /// Creates an analyte
+        /// </summary>
+        /// <param name="analyte">Analyte to be created</param>
+        /// <param name="cancellation"></param>
+        /// <returns>Boolean value indicating whether the analyte was successfully created</returns>
+        public async Task<bool> CreateAnalyteAsync(Analyte analyte, CancellationToken cancellation = default)
 		{
 			var endpoint = $"/operations/sample/v1/analyte?requestId={Guid.NewGuid()}";
 

--- a/src/ONE.ClientSDK/Operations/Sample/SampleApi.cs
+++ b/src/ONE.ClientSDK/Operations/Sample/SampleApi.cs
@@ -102,12 +102,12 @@ namespace ONE.ClientSDK.Operations.Sample
         /// <param name="endDate">The last day to create sample activities for.</param>
         /// <param name="propertyBag">Property bag for a sample activity.</param>
         /// <param name="cancellation"></param>
-        /// <returns>KeyValues collection that includes the id of the sample activity that was created.</returns>
+        /// <returns>KeyValues collection that includes details about the created sample activity.</returns>
         public async Task<List<KeyValue>> CreateOneActivityAsync(string operationId, DateTime endDate, ActivityCollectionPropertyBag propertyBag, CancellationToken cancellation = default)
         {
             var endpoint = $"/operations/sample/v1/{operationId}/{endDate:O}/activity";
             var apiResponse = await ExecuteRequest("CreateOneActivityAsync", HttpMethod.Post, endpoint, cancellation, propertyBag, true).ConfigureAwait(_continueOnCapturedContext);
-            return apiResponse?.Content?.KeyValues?.Items.ToList();
+            return apiResponse?.Content?.KeyValues?.Items.ToList() ?? new List<KeyValue>();
         }
 
         /// <summary>


### PR DESCRIPTION
AQI-10368: Updated SampleApi.CreateOneActivityAsync return and version

Breaking change is low risk because method was only added a few months back for use by mobile, and it is that very same mobile use case that requires the update.